### PR TITLE
mount all volumes with readonly=False

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The workflow state machine uses AWS Batch to actually run the Docker containers,
 - [Quick start -- deploying a BayerCLAW workflow](doc/quick-start.md)
 - [Tutorial -- detailed example of writing, deploying, and debugging](doc/tutorial.md)
 
-- [Installing BayerCLAW into a new AWS account](doc/deployment.md)
+- [Installing BayerCLAW into a new AWS account](doc/installation.md)
 - [The BayerCLAW language reference](doc/language.md)
 - [The BayerCLAW language -- scatter/gather](doc/scatter.md)
 - [The BayerCLAW language -- QC checks](doc/qc.md)

--- a/bclaw_runner/src/runner/dind.py
+++ b/bclaw_runner/src/runner/dind.py
@@ -67,7 +67,7 @@ def get_mounts(metadata: dict, parent_workspace: str, child_workspace: str) -> G
                 yield Mount(volume_spec["Destination"], volume_spec["Source"], type="bind", read_only=False)
 
             else:
-                yield Mount(volume_spec["Destination"], volume_spec["Source"], type="bind", read_only=True)
+                yield Mount(volume_spec["Destination"], volume_spec["Source"], type="bind", read_only=False)
 
         elif "DockerName" in volume_spec:
             # this handles per-job EFS mounts
@@ -77,7 +77,7 @@ def get_mounts(metadata: dict, parent_workspace: str, child_workspace: str) -> G
             # volume_spec:
             #   {'DockerName': 'ecs-jax-efs-test-EfsTestJobDef--1-1-fs-b5a4dd01-volume-bcd3a18fd8e28a9fe901',
             #    'Destination': '/efs'}
-            yield Mount(volume_spec["Destination"], volume_spec["DockerName"], type="volume", read_only=True,
+            yield Mount(volume_spec["Destination"], volume_spec["DockerName"], type="volume", read_only=False,
                         driver_config=DriverConfig("amazon-ecs-volume-plugin"))
 
 

--- a/bclaw_runner/tests/test_dind.py
+++ b/bclaw_runner/tests/test_dind.py
@@ -63,9 +63,9 @@ def test_get_mounts(monkeypatch):
     expect = [
         Mount(child_workspace, "/scratch/parent_workspace", type="bind", read_only=False),
         Mount("/.scratch", "/docker_scratch", type="bind", read_only=False),
-        Mount("/efs", "volume12345", type="volume", read_only=True,
+        Mount("/efs", "volume12345", type="volume", read_only=False,
               driver_config=DriverConfig("amazon-ecs-volume-plugin")),
-        Mount("/somewhere", "/miscellaneous/host/volume", type="bind", read_only=True)
+        Mount("/somewhere", "/miscellaneous/host/volume", type="bind", read_only=False)
     ]
 
     result = list(get_mounts(metadata, parent_workspace, child_workspace))

--- a/lambda/src/compiler/pkg/batch_resources.py
+++ b/lambda/src/compiler/pkg/batch_resources.py
@@ -151,7 +151,7 @@ def get_volume_info(step: Step) -> dict:
         mount_points.append({
             "SourceVolume": volume_name,
             "ContainerPath": filesystem["host_path"],
-            "ReadOnly": True,
+            "ReadOnly": False,
         })
 
     ret = {

--- a/lambda/tests/compiler/test_batch_resources.py
+++ b/lambda/tests/compiler/test_batch_resources.py
@@ -141,7 +141,7 @@ def test_get_volume_info(step_efs_specs):
                        },}
         assert mp == {"SourceVolume": vol["Name"],
                       "ContainerPath": spec["host_path"],
-                      "ReadOnly": True,}
+                      "ReadOnly": False,}
 
 
 @pytest.mark.parametrize("timeout, expect", [
@@ -307,7 +307,7 @@ def test_job_definition_rc(task_role, sample_batch_step, compiler_env):
                     {"ContainerPath": "/var/run/docker.sock", "SourceVolume": "docker_socket",   "ReadOnly": False},
                     {"ContainerPath": "/_bclaw_scratch",      "SourceVolume": "scratch",         "ReadOnly": False},
                     {"ContainerPath": "/.scratch",            "SourceVolume": "docker_scratch",  "ReadOnly": False},
-                    {"ContainerPath": "/step_efs",            "SourceVolume": "fs-12345-volume", "ReadOnly": True},
+                    {"ContainerPath": "/step_efs",            "SourceVolume": "fs-12345-volume", "ReadOnly": False},
                 ],
                 "Volumes": [
                     {"Name": "docker_socket",  "Host": {"SourcePath": "/var/run/docker.sock"}},


### PR DESCRIPTION
In order to resolve issues with S3 copy that we frequently experience with the event selection pipeline I needed to have EFS volumes mounted in write mode.