### PR TITLE
High-level codebase diagram representation

### DIFF
--- a/.codeboarding/Common Utilities & Notifications.md
+++ b/.codeboarding/Common Utilities & Notifications.md
@@ -1,0 +1,166 @@
+```mermaid
+graph LR
+    Initializer["Initializer"]
+    Compiler["Compiler"]
+    Common_Data_Utilities["Common Data Utilities"]
+    Notifications["Notifications"]
+    Runner_Orchestrator["Runner Orchestrator"]
+    Runner_Repository_Manager["Runner Repository Manager"]
+    Runner_String_Processor["Runner String Processor"]
+    Runner_Quality_Control["Runner Quality Control"]
+    Runner_Workspace_Manager["Runner Workspace Manager"]
+    Runner_Cache_Manager["Runner Cache Manager"]
+    Initializer -- "initiates_data_flow_to" --> Common_Data_Utilities
+    Initializer -- "prepares_job_for" --> Runner_Repository_Manager
+    Compiler -- "transforms_templates_using" --> Common_Data_Utilities
+    Runner_Orchestrator -- "manages_repository_operations_through" --> Runner_Repository_Manager
+    Runner_Orchestrator -- "applies_string_transformations_via" --> Runner_String_Processor
+    Runner_Orchestrator -- "executes_tasks_in" --> Runner_Workspace_Manager
+    Runner_Orchestrator -- "ensures_quality_with" --> Runner_Quality_Control
+    Runner_Orchestrator -- "retrieves_cached_inputs_from" --> Runner_Cache_Manager
+    Runner_Repository_Manager -- "leverages_common_file_utilities_from" --> Common_Data_Utilities
+    Common_Data_Utilities -- "provides_core_data_handling_to" --> Runner_Repository_Manager
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This system, BayerCLAW, provides a robust framework for orchestrating and executing jobs. It handles the initial launch process from S3, compiles job templates, manages data manipulation and repository interactions, and facilitates notifications for workflow state changes. The runner component orchestrates the execution flow, including string substitutions, workspace management, caching, and quality control checks, ensuring efficient and reliable job processing.
+
+### Initializer
+This component is responsible for handling the initial S3 launch process. It reads job data from S3, performs substitutions, checks for recursive launches, copies job data to the repository, and writes extended job data back to S3.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/initializer/initializer.py#L79-L113" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.initializer.initializer:handle_s3_launch` (79:113)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/initializer/initializer.py#L19-L30" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.initializer.initializer.read_s3_object` (19:30)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/initializer/initializer.py#L42-L45" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.initializer.initializer.substitute_job_data` (42:45)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/initializer/initializer.py#L48-L53" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.initializer.initializer.check_recursive_launch` (48:53)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/initializer/initializer.py#L56-L63" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.initializer.initializer.copy_job_data_to_repo` (56:63)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/initializer/initializer.py#L66-L76" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.initializer.initializer.write_extended_job_data_object` (66:76)</a>
+
+
+### Compiler
+The Compiler component is responsible for compiling templates, including handling state machine resources, capitalizing top-level keys, and substituting parameters. It also manages state machine versions and aliases.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/compiler.py#L17-L61" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.compiler:compile_template` (17:61)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/compiler.py#L12-L14" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.compiler._capitalize_top_level_keys` (12:14)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/util.py#L57-L66" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.util.substitute_params` (57:66)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L175-L210" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources.handle_state_machine` (175:210)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L243-L254" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources.add_definition_substitutions` (243:254)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L213-L224" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources.state_machine_version_rc` (213:224)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L227-L240" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources.state_machine_alias_rc` (227:240)</a>
+
+
+### Common Data Utilities
+This component provides shared utility functions for data manipulation, including substituting job data into strings and filenames, and selecting file contents from various formats like JSON, YAML, and CSV. It also includes repository utility functions for managing S3 files.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/substitutions.py#L24-L39" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.substitutions:substitute_job_data` (24:39)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/substitutions.py#L42-L59" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.substitutions:substitute_into_filenames` (42:59)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/repo_utils.py#L65-L67" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.repo_utils.Repo:from_uri` (65:67)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/repo_utils.py#L81-L86" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.repo_utils.Repo:qualify` (81:86)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/repo_utils.py#L88-L90" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.repo_utils.Repo:sub_repo` (88:90)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/repo_utils.py#L18-L24" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.repo_utils.S3File` (18:24)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/file_select.py#L49-L78" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.file_select:select_file_contents` (49:78)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/file_select.py#L37-L39" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.file_select.slurp` (37:39)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/file_select.py#L16-L18" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.file_select.read_json` (16:18)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/file_select.py#L21-L23" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.file_select.read_json_lines` (21:23)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/file_select.py#L26-L28" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.file_select.read_yaml` (26:28)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/file_select.py#L31-L34" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.file_select.read_csv` (31:34)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/file_select.py#L42-L46" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.file_select.stringify` (42:46)</a>
+
+
+### Notifications
+This component is responsible for generating and sending notification messages, specifically for state changes, by creating message attributes and SNS payloads.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/notifications/notifications.py#L102-L116" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.notifications.notifications:lambda_handler` (102:116)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/notifications/notifications.py#L56-L86" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.notifications.notifications.make_message_attributes` (56:86)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/notifications/notifications.py#L12-L53" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.notifications.notifications.make_state_change_message` (12:53)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/notifications/notifications.py#L89-L99" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.notifications.notifications.make_sns_payload` (89:99)</a>
+
+
+### Runner Orchestrator
+This is the main entry point for the BayerCLAW runner. It orchestrates the entire execution flow, including repository interactions, string substitutions, workspace management, caching, input/output handling, and quality control checks.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/runner_main.py#L43-L116" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.runner_main:main` (43:116)</a>
+
+
+### Runner Repository Manager
+This component manages all repository-related operations for the runner. It handles checking for previous runs, verifying file existence, clearing run status, reading job data, downloading inputs, and uploading outputs to the repository.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L50-L241" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository` (50:241)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L210-L223" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository.check_for_previous_run` (210:223)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L89-L111" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository.check_files_exist` (89:111)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L225-L231" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository.clear_run_status` (225:231)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L65-L71" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository.read_job_data` (65:71)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L151-L158" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository.download_inputs` (151:158)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L203-L208" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository.upload_outputs` (203:208)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L233-L241" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository.put_run_status` (233:241)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L114-L129" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository._inputerator` (114:129)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L171-L201" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository._upload_that` (171:201)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L27-L29" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo._is_glob` (27:29)</a>
+- `BayerCLAW.bclaw_runner.src.runner.repo._s3_file_exists` (full file reference)
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L32-L47" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo._expand_s3_glob` (32:47)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L18-L19" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.SkipExecution` (18:19)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L22-L24" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo._file_metadata` (22:24)</a>
+
+
+### Runner String Processor
+This component is dedicated to performing various string substitutions required by the runner, including general substitutions and specific image tag substitutions.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/string_subs.py#L16-L27" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.string_subs:substitute` (16:27)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/string_subs.py#L30-L39" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.string_subs.substitute_image_tag` (30:39)</a>
+
+
+### Runner Quality Control
+This component is responsible for performing quality control checks during the runner's execution. It can also trigger an abortion of the execution if checks fail.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/qc_check.py#L58-L66" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.qc_check.do_checks` (58:66)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/qc_check.py#L17-L34" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.qc_check.abort_execution` (17:34)</a>
+
+
+### Runner Workspace Manager
+This component manages the runner's local workspace. It handles writing job data files and executing commands within the workspace environment.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/workspace.py#L21-L35" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.workspace.workspace` (21:35)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/workspace.py#L38-L41" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.workspace.write_job_data_file` (38:41)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/workspace.py#L44-L69" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.workspace.run_commands` (44:69)</a>
+
+
+### Runner Cache Manager
+This component is responsible for managing the caching of reference inputs for the runner, optimizing data retrieval.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/cache.py#L68-L82" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.cache.get_reference_inputs` (68:82)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Job Orchestration & Workflow Definition.md
+++ b/.codeboarding/Job Orchestration & Workflow Definition.md
@@ -1,0 +1,165 @@
+```mermaid
+graph LR
+    Initializer["Initializer"]
+    Job_Definition_Registrar["Job Definition Registrar"]
+    Job_Router["Job Router"]
+    Chooser_Logic["Chooser Logic"]
+    Compiler_Core["Compiler Core"]
+    Compiler_State_Machine_Builder["Compiler State Machine Builder"]
+    Compiler_Step_Handlers["Compiler Step Handlers"]
+    Compiler_Validation["Compiler Validation"]
+    Compiler_Utilities["Compiler Utilities"]
+    Initializer -- "Prepares job input for" --> Job_Router
+    Compiler_Core -- "Orchestrates compilation of" --> Compiler_State_Machine_Builder
+    Compiler_State_Machine_Builder -- "Delegates step processing to" --> Compiler_Step_Handlers
+    Compiler_State_Machine_Builder -- "Utilizes validation from" --> Compiler_Validation
+    Compiler_Step_Handlers -- "Leverages common functions from" --> Compiler_Utilities
+    Compiler_Core -- "Applies utilities from" --> Compiler_Utilities
+    Job_Router -- "Identifies and initiates" --> Compiler_State_Machine_Builder
+    Compiler_Step_Handlers -- "May recursively invoke" --> Compiler_State_Machine_Builder
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Job Orchestration & Workflow Definition component is responsible for the initial setup, routing, and comprehensive compilation of high-level workflow definitions into executable AWS Step Functions state machine language. This includes handling various step types such as batch, scatter-gather, parallel, sub-pipeline, native, and chooser steps, along with their validation. It acts as the central hub for transforming abstract job specifications into concrete, executable workflows.
+
+### Initializer
+This component is responsible for the initial setup of a job execution. It reads job data from S3, performs variable substitutions, ensures no recursive launches, copies job data to a designated repository, and writes extended job data for subsequent steps. It acts as the entry point for S3-triggered workflows.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/initializer/initializer.py#L79-L113" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.initializer.initializer:handle_s3_launch` (79:113)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/initializer/initializer.py#L116-L145" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.initializer.initializer:lambda_handler` (116:145)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/initializer/initializer.py#L19-L30" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.initializer.initializer.read_s3_object` (19:30)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/initializer/initializer.py#L42-L45" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.initializer.initializer.substitute_job_data` (42:45)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/initializer/initializer.py#L48-L53" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.initializer.initializer.check_recursive_launch` (48:53)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/initializer/initializer.py#L56-L63" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.initializer.initializer.copy_job_data_to_repo` (56:63)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/initializer/initializer.py#L66-L76" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.initializer.initializer.write_extended_job_data_object` (66:76)</a>
+
+
+### Job Definition Registrar
+This component handles the registration and modification of job definitions. It processes incoming requests, potentially edits job specifications, and generates appropriate responses, likely for managing job metadata or configurations within the system.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/job_def/register.py#L79-L129" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.job_def.register:lambda_handler` (79:129)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/job_def/register.py#L47-L64" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.job_def.register:responder` (47:64)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/job_def/register.py#L24-L35" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.job_def.register.Response` (24:35)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/job_def/register.py#L38-L43" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.job_def.register.respond` (38:43)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/job_def/register.py#L67-L76" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.job_def.register.edit_spec` (67:76)</a>
+
+
+### Job Router
+The Job Router component is responsible for determining the correct state machine for execution and generating a unique execution name. It normalizes and shortens filenames to create suitable identifiers for workflow executions.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/router/job_router.py#L53-L99" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.router.job_router:lambda_handler` (53:99)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/router/job_router.py#L38-L43" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.router.job_router:make_execution_name` (38:43)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/router/job_router.py#L32-L35" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.router.job_router.normalize` (32:35)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/router/job_router.py#L26-L29" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.router.job_router.shorten_filename` (26:29)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/router/job_router.py#L14-L23" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.router.job_router.get_state_machine_name` (14:23)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/router/job_router.py#L46-L50" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.router.job_router.get_state_machine_arn` (46:50)</a>
+
+
+### Chooser Logic
+This component implements conditional logic for workflows. It loads values, potentially from S3, and evaluates expressions to make choices or direct workflow paths based on predefined conditions.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/chooser/multichooser.py#L71-L100" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.chooser.multichooser:lambda_handler` (71:100)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/chooser/multichooser.py#L39-L52" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.chooser.multichooser:load_vals` (39:52)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/chooser/multichooser.py#L60-L68" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.chooser.multichooser:run_exprs` (60:68)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/chooser/multichooser.py#L22-L36" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.chooser.multichooser.load_s3_object` (22:36)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/chooser/multichooser.py#L55-L57" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.chooser.multichooser.eval_this` (55:57)</a>
+
+
+### Compiler Core
+This is the central component for compiling workflow templates into executable state machine definitions. It orchestrates the overall compilation process, including parameter substitution and delegating to other compiler sub-components for handling specific step types and state machine generation.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/compiler.py#L17-L61" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.compiler:compile_template` (17:61)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/compiler.py#L12-L14" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.compiler._capitalize_top_level_keys` (12:14)</a>
+
+
+### Compiler State Machine Builder
+This component is dedicated to constructing and managing AWS Step Functions state machine definitions. It creates branches, processes individual steps by delegating to specific step handlers, and handles the output of the compiled state machine, including writing it to S3.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L24-L44" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources:make_initializer_step` (24:44)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L69-L108" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources:process_step` (69:108)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L111-L133" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources:make_branch` (111:133)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L175-L210" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources:handle_state_machine` (175:210)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L47-L66" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources.make_step_list` (47:66)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L148-L172" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources.write_state_machine_to_s3` (148:172)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L136-L145" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources.write_state_machine_to_fh` (136:145)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L243-L254" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources.add_definition_substitutions` (243:254)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L213-L224" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources.state_machine_version_rc` (213:224)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L227-L240" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources.state_machine_alias_rc` (227:240)</a>
+
+
+### Compiler Step Handlers
+This component provides specialized logic for processing and generating definitions for various types of workflow steps, including scatter/gather, batch jobs, sub-pipelines, native AWS Lambda steps, parallel executions, and chooser steps. It integrates with utility functions for common operational aspects like logging and retries.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/scatter_gather_resources.py#L11-L28" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.scatter_gather_resources:scatter_step` (11:28)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/scatter_gather_resources.py#L42-L80" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.scatter_gather_resources:map_step` (42:80)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/scatter_gather_resources.py#L83-L100" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.scatter_gather_resources:scatter_init_step` (83:100)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/scatter_gather_resources.py#L103-L119" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.scatter_gather_resources:gather_step` (103:119)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/scatter_gather_resources.py#L122-L145" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.scatter_gather_resources:handle_scatter_gather` (122:145)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/chooser_resources.py#L20-L60" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.chooser_resources:handle_chooser_step` (20:60)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/enhanced_parallel_resources.py#L9-L78" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.enhanced_parallel_resources:handle_parallel_step` (9:78)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/subpipe_resources.py#L9-L26" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.subpipe_resources:file_submit_step` (9:26)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/subpipe_resources.py#L60-L79" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.subpipe_resources:file_retrieve_step` (60:79)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/subpipe_resources.py#L82-L96" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.subpipe_resources:handle_subpipe` (82:96)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/native_step_resources.py#L8-L44" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.native_step_resources:handle_native_step` (8:44)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/batch_resources.py#L68-L87" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.batch_resources:get_resource_requirements` (68:87)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/batch_resources.py#L153-L158" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.batch_resources:get_timeout` (153:158)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/batch_resources.py#L184-L266" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.batch_resources:job_definition_rc` (184:266)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/batch_resources.py#L290-L377" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.batch_resources:batch_step` (290:377)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/batch_resources.py#L380-L402" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.batch_resources:handle_batch` (380:402)</a>
+
+
+### Compiler Validation
+This component provides a set of validation functions used by the compiler to ensure that various workflow steps (batch, native, parallel, scatter, subpipe, chooser) adhere to predefined rules and structures, raising errors for invalid configurations.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/validation.py#L274-L279" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.validation:_validator` (274:279)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/validation.py#L282-L284" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.validation:validate_batch_step` (282:284)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/validation.py#L287-L289" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.validation:validate_native_step` (287:289)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/validation.py#L292-L294" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.validation:validate_parallel_step` (292:294)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/validation.py#L297-L299" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.validation:validate_scatter_step` (297:299)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/validation.py#L302-L304" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.validation:validate_subpipe_step` (302:304)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/validation.py#L307-L309" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.validation:validate_chooser_step` (307:309)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/validation.py#L11-L29" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.validation.CompilerError` (11:29)</a>
+
+
+### Compiler Utilities
+This component provides common utility functions that support various parts of the compiler and other related components. These utilities include parameter substitution, logging blocks, retry mechanisms, logical name generation, and time string conversions.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/util.py#L57-L66" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.util:substitute_params` (57:66)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/util.py#L69-L81" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.util.lambda_logging_block` (69:81)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/util.py#L93-L116" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.util.lambda_retry` (93:116)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/util.py#L46-L49" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.util.make_logical_name` (46:49)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/util.py#L84-L90" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.util.time_string_to_seconds` (84:90)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Quality Control & Termination.md
+++ b/.codeboarding/Quality Control & Termination.md
@@ -1,0 +1,52 @@
+```mermaid
+graph LR
+    QCChecker["QCChecker"]
+    TerminationHandler["TerminationHandler"]
+    LambdaQCChecker["LambdaQCChecker"]
+    RunnerMain -- "uses" --> QCChecker
+    RunnerMain -- "integrates" --> TerminationHandler
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This subsystem is responsible for ensuring the quality of job execution and managing instance termination. It encompasses two primary quality control mechanisms: one operating within the AWS Lambda environment for pre-execution or post-processing checks, and another integrated into the main job runner for in-execution validation. Additionally, it includes a robust termination handler specifically designed to detect and respond to AWS EC2 spot instance termination notices, allowing for graceful shutdown and data preservation.
+
+### QCChecker
+Performs quality control checks on the executed job within the runner environment. It runs all defined QC checks by evaluating expressions against QC result files and can abort the Step Functions workflow execution if failures are detected.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/qc_check.py#L11-L14" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.qc_check:QCFailure` (11:14)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/qc_check.py#L17-L34" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.qc_check:abort_execution` (17:34)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/qc_check.py#L36-L41" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.qc_check:run_one_qc_check` (36:41)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/qc_check.py#L44-L55" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.qc_check:run_all_qc_checks` (44:55)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/qc_check.py#L58-L66" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.qc_check:do_checks` (58:66)</a>
+
+
+### TerminationHandler
+Manages graceful termination for instances, particularly for spot instances. It periodically checks the EC2 metadata service for termination notices and logs warnings to facilitate graceful shutdown.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/termination.py#L52-L71" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.termination:spot_termination_checker` (52:71)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/termination.py#L12-L21" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.termination:_this_is_a_spot_instance` (12:21)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/termination.py#L24-L32" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.termination:_do_termination_check` (24:32)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/termination.py#L35-L48" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.termination:_termination_checker_impl` (35:48)</a>
+
+
+### LambdaQCChecker
+A dedicated quality control component for the AWS Lambda environment. It reads QC results from an S3 path, evaluates a specified expression, and if the check fails, it stops the associated Step Functions execution and raises a QCFailed exception.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/qc_checker/qc_checker.py#L19-L45" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.qc_checker.qc_checker:lambda_handler` (19:45)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/qc_checker/qc_checker.py#L14-L16" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.qc_checker.qc_checker:QCFailed` (14:16)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Runner Execution Environment.md
+++ b/.codeboarding/Runner Execution Environment.md
@@ -1,0 +1,54 @@
+```mermaid
+graph LR
+    WorkspaceManager["WorkspaceManager"]
+    DockerContainerManager["DockerContainerManager"]
+    SignalTrapper["SignalTrapper"]
+    WorkspaceManager -- "executes commands using" --> DockerContainerManager
+    WorkspaceManager -- "handles failures from" --> DockerContainerManager
+    DockerContainerManager -- "uses" --> SignalTrapper
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+The Runner Execution Environment subsystem manages the local execution environment for the runner, facilitating the execution of user-defined commands within a dedicated workspace and orchestrating child containers using Docker-in-Docker. It integrates components for workspace management, Docker container operations, and signal handling to ensure robust and controlled command execution.
+
+### WorkspaceManager
+The WorkspaceManager component is responsible for creating and managing a temporary workspace for the execution of commands. It provides functionalities for writing job data to a file and executing user-defined commands within a Docker container, handling potential failures during command execution.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/workspace.py#L21-L35" target="_blank" rel="noopener noreferrer">`bclaw_runner.src.runner.workspace:workspace` (21:35)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/workspace.py#L38-L41" target="_blank" rel="noopener noreferrer">`bclaw_runner.src.runner.workspace:write_job_data_file` (38:41)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/workspace.py#L44-L69" target="_blank" rel="noopener noreferrer">`bclaw_runner.src.runner.workspace:run_commands` (44:69)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/workspace.py#L14-L17" target="_blank" rel="noopener noreferrer">`bclaw_runner.src.runner.workspace.UserCommandsFailed` (14:17)</a>
+
+
+### DockerContainerManager
+The DockerContainerManager component handles interactions with Docker to run child containers. It is responsible for pulling Docker images, retrieving container metadata, managing mounts and environment variables, and handling GPU requests for container execution.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/dind.py#L133-L181" target="_blank" rel="noopener noreferrer">`bclaw_runner.src.runner.dind:run_child_container` (133:181)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/dind.py#L108-L130" target="_blank" rel="noopener noreferrer">`bclaw_runner.src.runner.dind:pull_image` (108:130)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/dind.py#L98-L105" target="_blank" rel="noopener noreferrer">`bclaw_runner.src.runner.dind:get_auth` (98:105)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/dind.py#L42-L46" target="_blank" rel="noopener noreferrer">`bclaw_runner.src.runner.dind:get_container_metadata` (42:46)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/dind.py#L49-L89" target="_blank" rel="noopener noreferrer">`bclaw_runner.src.runner.dind:get_mounts` (49:89)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/dind.py#L92-L95" target="_blank" rel="noopener noreferrer">`bclaw_runner.src.runner.dind:get_environment_vars` (92:95)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/dind.py#L29-L39" target="_blank" rel="noopener noreferrer">`bclaw_runner.src.runner.dind:get_gpu_requests` (29:39)</a>
+
+
+### SignalTrapper
+The SignalTrapper component is responsible for trapping and handling signals, specifically for stopping child containers gracefully upon receiving termination signals.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/signal_trapper.py#L26-L42" target="_blank" rel="noopener noreferrer">`bclaw_runner.src.runner.signal_trapper.signal_trapper` (26:42)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Workflow Execution & Data Management.md
+++ b/.codeboarding/Workflow Execution & Data Management.md
@@ -1,0 +1,183 @@
+```mermaid
+graph LR
+    Workflow_Execution_Data_Management["Workflow Execution & Data Management"]
+    Subpipe_Data_Manager["Subpipe Data Manager"]
+    Workflow_Compiler["Workflow Compiler"]
+    Scatter_Gather_Definition["Scatter-Gather Definition"]
+    Subpipe_Step_Builder["Subpipe Step Builder"]
+    Scatter_Data_Processor["Scatter Data Processor"]
+    S3_Repository_Abstraction["S3 Repository Abstraction"]
+    Runner_Orchestrator["Runner Orchestrator"]
+    Runner_S3_Data_Handler["Runner S3 Data Handler"]
+    Local_Execution_Environment["Local Execution Environment"]
+    Runtime_Utilities["Runtime Utilities"]
+    Workflow_Compiler -- "defines steps for" --> Scatter_Gather_Definition
+    Workflow_Compiler -- "defines steps for" --> Subpipe_Step_Builder
+    Workflow_Compiler -- "uses" --> S3_Repository_Abstraction
+    Scatter_Gather_Definition -- "invokes" --> Scatter_Data_Processor
+    Subpipe_Step_Builder -- "interacts with" --> Subpipe_Data_Manager
+    Runner_Orchestrator -- "manages" --> Runner_S3_Data_Handler
+    Runner_Orchestrator -- "executes via" --> Local_Execution_Environment
+    Runner_Orchestrator -- "leverages" --> Runtime_Utilities
+    Runner_S3_Data_Handler -- "utilizes" --> S3_Repository_Abstraction
+    Scatter_Data_Processor -- "uses" --> S3_Repository_Abstraction
+    Subpipe_Data_Manager -- "uses" --> S3_Repository_Abstraction
+    Workflow_Execution_Data_Management -- "orchestrates" --> Runner_Orchestrator
+    Workflow_Execution_Data_Management -- "manages data with" --> Runner_S3_Data_Handler
+    Workflow_Execution_Data_Management -- "utilizes" --> Local_Execution_Environment
+    Workflow_Execution_Data_Management -- "uses" --> Runtime_Utilities
+    Workflow_Execution_Data_Management -- "handles sub-pipeline data via" --> Subpipe_Data_Manager
+    Workflow_Execution_Data_Management -- "handles scatter-gather data via" --> Scatter_Data_Processor
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This system orchestrates the entire job execution lifecycle within the `bclaw_runner`, managing data handling, sub-pipeline execution, and scatter-gather operations. It compiles workflows into AWS Step Functions, processes data for parallel execution, and provides abstractions for S3 interactions, ensuring robust and scalable workflow management.
+
+### Workflow Execution & Data Management
+The overarching component responsible for orchestrating the entire job execution lifecycle within `bclaw_runner`, including comprehensive data handling (S3 interactions, caching), and facilitating data exchange for sub-pipelines and scatter-gather operations. It acts as the central control for the runtime environment.
+
+
+**Related Classes/Methods**:
+
+- `BayerCLAW.bclaw_runner.src.runner.runner_main` (full file reference)
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/preamble.py#L7-L14" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.preamble.log_preamble` (7:14)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/tagging.py#L12-L27" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.tagging.tag_this_instance` (12:27)</a>
+- `BayerCLAW.bclaw_runner.src.runner.repo` (full file reference)
+- `BayerCLAW.bclaw_runner.src.runner.cache` (full file reference)
+- `BayerCLAW.lambda.src.subpipes.subpipes` (full file reference)
+- `BayerCLAW.lambda.src.scatter.scatter` (full file reference)
+
+
+### Subpipe Data Manager
+This component is responsible for managing file transfers and job data for sub-pipelines. It handles the submission of data to a subpipe and the retrieval of results from it, primarily interacting with S3 for data storage.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/subpipes/subpipes.py#L58-L162" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.subpipes.subpipes:lambda_handler` (58:162)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/subpipes/subpipes.py#L18-L25" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.subpipes.subpipes.get_s3_object` (18:25)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/subpipes/subpipes.py#L29-L33" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.subpipes.subpipes.put_s3_object` (29:33)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/subpipes/subpipes.py#L36-L55" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.subpipes.subpipes.copy_file_impl` (36:55)</a>
+
+
+### Workflow Compiler
+This component is responsible for compiling and defining AWS Step Functions state machines. It orchestrates various step types, including scatter-gather, batch, subpipe, native, chooser, and parallel steps, into a coherent workflow definition.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L69-L108" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources:process_step` (69:108)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L111-L133" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources:make_branch` (111:133)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L175-L210" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources:handle_state_machine` (175:210)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L24-L44" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources:make_initializer_step` (24:44)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/state_machine_resources.py#L148-L172" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.state_machine_resources:write_state_machine_to_s3` (148:172)</a>
+
+
+### Scatter-Gather Definition
+This component defines the structure and steps for scatter-gather operations within the state machine. It includes the initial scatter step, the map step for parallel processing, and the final gather step to collect results.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/scatter_gather_resources.py#L122-L145" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.scatter_gather_resources:handle_scatter_gather` (122:145)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/scatter_gather_resources.py#L11-L28" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.scatter_gather_resources:scatter_step` (11:28)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/scatter_gather_resources.py#L42-L80" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.scatter_gather_resources:map_step` (42:80)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/scatter_gather_resources.py#L103-L119" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.scatter_gather_resources:gather_step` (103:119)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/scatter_gather_resources.py#L83-L100" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.scatter_gather_resources:scatter_init_step` (83:100)</a>
+
+
+### Subpipe Step Builder
+This component specifically builds the individual steps involved in executing a subpipe within a larger state machine. It includes steps for submitting files, running the subpipe state machine, and retrieving output files.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/subpipe_resources.py#L82-L96" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.subpipe_resources:handle_subpipe` (82:96)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/subpipe_resources.py#L9-L26" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.subpipe_resources:file_submit_step` (9:26)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/subpipe_resources.py#L29-L57" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.subpipe_resources:run_subpipe_step` (29:57)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/compiler/pkg/subpipe_resources.py#L60-L79" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.compiler.pkg.subpipe_resources:file_retrieve_step` (60:79)</a>
+
+
+### Scatter Data Processor
+This component is responsible for processing and expanding scatter data for parallel execution. It handles various data sources and formats, including static lists, job data references, file contents, and S3 globs, to prepare data for map steps.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/scatter/scatter.py#L133-L190" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.scatter.scatter:lambda_handler` (133:190)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/scatter/scatter.py#L48-L50" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.scatter.scatter.expand_scatter_data` (48:50)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/scatter/scatter.py#L53-L105" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.scatter.scatter._expand_scatter_data_impl` (53:105)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/scatter/scatter.py#L31-L45" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.scatter.scatter.expand_glob` (31:45)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/scatter/scatter.py#L108-L113" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.scatter.scatter.scatterator` (108:113)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/scatter/scatter.py#L22-L28" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.scatter.scatter.get_job_data` (22:28)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/scatter/scatter.py#L116-L130" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.scatter.scatter.write_job_data_template` (116:130)</a>
+
+
+### S3 Repository Abstraction
+This foundational component provides a high-level abstraction for interacting with S3 buckets and prefixes as repositories. It simplifies file and path management, enabling consistent access and manipulation of data within the system.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/repo_utils.py#L59-L93" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.repo_utils.Repo` (59:93)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/repo_utils.py#L18-L24" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.repo_utils.S3File` (18:24)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/repo_utils.py#L65-L67" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.repo_utils.Repo.from_uri` (65:67)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/repo_utils.py#L81-L86" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.repo_utils.Repo.qualify` (81:86)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/lambda/src/common/python/repo_utils.py#L88-L90" target="_blank" rel="noopener noreferrer">`BayerCLAW.lambda.src.common.python.repo_utils.Repo.sub_repo` (88:90)</a>
+
+
+### Runner Orchestrator
+This is the primary control flow component for the 'bclaw_runner' application. It manages the overall execution, including input/output handling, command execution, and error handling, orchestrating the various stages of a job run.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/runner_main.py#L43-L116" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.runner_main:main` (43:116)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/runner_main.py#L119-L146" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.runner_main:cli` (119:146)</a>
+
+
+### Runner S3 Data Handler
+This component specifically handles all S3-related data operations for the 'bclaw_runner'. It manages reading and writing job data, checking for previous runs, downloading inputs, and uploading outputs, ensuring data persistence and run state management.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L50-L241" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository` (50:241)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L65-L71" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository.read_job_data` (65:71)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L89-L111" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository.check_files_exist` (89:111)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L151-L158" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository.download_inputs` (151:158)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L203-L208" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository.upload_outputs` (203:208)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L210-L223" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository.check_for_previous_run` (210:223)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/repo.py#L233-L241" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.repo.Repository.put_run_status` (233:241)</a>
+
+
+### Local Execution Environment
+This component provides and manages the temporary local file system workspace for the 'bclaw_runner'. It also handles the execution of shell commands within a containerized environment and manages the writing of job data files to the workspace.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/workspace.py#L21-L35" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.workspace.workspace` (21:35)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/workspace.py#L38-L41" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.workspace.write_job_data_file` (38:41)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/workspace.py#L44-L69" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.workspace.run_commands` (44:69)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/workspace.py#L14-L17" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.workspace.UserCommandsFailed` (14:17)</a>
+
+
+### Runtime Utilities
+This component is a collection of supporting utilities used during runtime. It includes functionalities for caching reference inputs, performing string substitutions for dynamic values, and conducting quality control checks on execution results.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/cache.py#L68-L82" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.cache.get_reference_inputs` (68:82)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/string_subs.py#L16-L27" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.string_subs.substitute` (16:27)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/string_subs.py#L30-L39" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.string_subs.substitute_image_tag` (30:39)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/qc_check.py#L58-L66" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.qc_check.do_checks` (58:66)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/qc_check.py#L17-L34" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.qc_check.abort_execution` (17:34)</a>
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,103 @@
+```mermaid
+graph LR
+    Job_Orchestration_Workflow_Definition["Job Orchestration & Workflow Definition"]
+    Workflow_Execution_Data_Management["Workflow Execution & Data Management"]
+    Runner_Execution_Environment["Runner Execution Environment"]
+    Quality_Control_Termination["Quality Control & Termination"]
+    Common_Utilities_Notifications["Common Utilities & Notifications"]
+    Job_Orchestration_Workflow_Definition -- "initiates job processing" --> Workflow_Execution_Data_Management
+    Job_Orchestration_Workflow_Definition -- "defines execution patterns for" --> Workflow_Execution_Data_Management
+    Job_Orchestration_Workflow_Definition -- "utilizes" --> Common_Utilities_Notifications
+    Job_Orchestration_Workflow_Definition -- "leverages" --> Common_Utilities_Notifications
+    Job_Orchestration_Workflow_Definition -- "validates with" --> Quality_Control_Termination
+    Workflow_Execution_Data_Management -- "executes commands via" --> Runner_Execution_Environment
+    Workflow_Execution_Data_Management -- "interacts with" --> Quality_Control_Termination
+    Workflow_Execution_Data_Management -- "applies transformations using" --> Common_Utilities_Notifications
+    Runner_Execution_Environment -- "reports status to" --> Workflow_Execution_Data_Management
+    click Job_Orchestration_Workflow_Definition href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/BayerCLAW/Job Orchestration & Workflow Definition.md" "Details"
+    click Workflow_Execution_Data_Management href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/BayerCLAW/Workflow Execution & Data Management.md" "Details"
+    click Runner_Execution_Environment href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/BayerCLAW/Runner Execution Environment.md" "Details"
+    click Quality_Control_Termination href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/BayerCLAW/Quality Control & Termination.md" "Details"
+    click Common_Utilities_Notifications href "https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/BayerCLAW/Common Utilities & Notifications.md" "Details"
+```
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+## Component Details
+
+This graph illustrates the architecture of BayerCLAW, a system designed for orchestrating and executing complex bioinformatics workflows. The main flow involves the `Job Orchestration & Workflow Definition` component, which handles initial job setup, routing, and compiles high-level workflow definitions into executable state machine language. This compiled workflow is then passed to the `Workflow Execution & Data Management` component, which manages the actual execution, data handling, and specific workflow patterns like scatter-gather. The `Runner Execution Environment` provides the isolated environment for command execution. Throughout the process, `Quality Control & Termination` ensures correctness and manages instance lifecycle, while `Common Utilities & Notifications` provides shared services for data manipulation and communication.
+
+### Job Orchestration & Workflow Definition
+Manages the initial setup, routing, and comprehensive compilation of high-level workflow definitions into executable AWS Step Functions state machine language, including handling various step types (batch, scatter-gather, parallel, sub-pipeline, native, chooser) and their validation.
+
+
+**Related Classes/Methods**:
+
+- `BayerCLAW.lambda.src.initializer.initializer` (full file reference)
+- `BayerCLAW.lambda.src.router.job_router` (full file reference)
+- `BayerCLAW.lambda.src.job_def.register` (full file reference)
+- `BayerCLAW.lambda.src.compiler.pkg.compiler` (full file reference)
+- `BayerCLAW.lambda.src.compiler.pkg.state_machine_resources` (full file reference)
+- `BayerCLAW.lambda.src.compiler.pkg.util` (full file reference)
+- `BayerCLAW.lambda.src.compiler.pkg.validation` (full file reference)
+- `BayerCLAW.lambda.src.compiler.pkg.scatter_gather_resources` (full file reference)
+- `BayerCLAW.lambda.src.compiler.pkg.chooser_resources` (full file reference)
+- `BayerCLAW.lambda.src.compiler.pkg.enhanced_parallel_resources` (full file reference)
+- `BayerCLAW.lambda.src.compiler.pkg.subpipe_resources` (full file reference)
+- `BayerCLAW.lambda.src.compiler.pkg.native_step_resources` (full file reference)
+- `BayerCLAW.lambda.src.compiler.pkg.batch_resources` (full file reference)
+- `BayerCLAW.lambda.src.chooser.multichooser` (full file reference)
+
+
+### Workflow Execution & Data Management
+The central control component for the `bclaw_runner`, managing the entire job execution lifecycle, including data handling (S3 repository interactions, caching), and facilitating data exchange for sub-pipelines and scatter-gather operations during execution.
+
+
+**Related Classes/Methods**:
+
+- `BayerCLAW.bclaw_runner.src.runner.runner_main` (full file reference)
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/preamble.py#L7-L14" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.preamble.log_preamble` (7:14)</a>
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/tagging.py#L12-L27" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.tagging.tag_this_instance` (12:27)</a>
+- `BayerCLAW.bclaw_runner.src.runner.repo` (full file reference)
+- `BayerCLAW.bclaw_runner.src.runner.cache` (full file reference)
+- `BayerCLAW.lambda.src.subpipes.subpipes` (full file reference)
+- `BayerCLAW.lambda.src.scatter.scatter` (full file reference)
+
+
+### Runner Execution Environment
+Manages the local execution environment for the runner, responsible for running user-defined commands within that workspace and handling the execution of child containers using Docker-in-Docker.
+
+
+**Related Classes/Methods**:
+
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/workspace.py#L21-L35" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.workspace` (21:35)</a>
+- `BayerCLAW.bclaw_runner.src.runner.dind` (full file reference)
+- <a href="https://github.com/Bayer-Group/BayerCLAW/blob/master/bclaw_runner/src/runner/signal_trapper.py#L26-L42" target="_blank" rel="noopener noreferrer">`BayerCLAW.bclaw_runner.src.runner.signal_trapper.signal_trapper` (26:42)</a>
+
+
+### Quality Control & Termination
+Performs quality control checks both within the AWS Lambda environment and during job execution, and manages the graceful termination of instances, particularly for spot instances.
+
+
+**Related Classes/Methods**:
+
+- `BayerCLAW.lambda.src.qc_checker.qc_checker` (full file reference)
+- `BayerCLAW.bclaw_runner.src.runner.qc_check` (full file reference)
+- `BayerCLAW.bclaw_runner.src.runner.termination` (full file reference)
+
+
+### Common Utilities & Notifications
+Provides shared utility functions for data manipulation, including general substitutions, repository operations, reading various file formats, and generating/sending notifications related to workflow state changes.
+
+
+**Related Classes/Methods**:
+
+- `BayerCLAW.lambda.src.common.python.substitutions` (full file reference)
+- `BayerCLAW.lambda.src.common.python.repo_utils` (full file reference)
+- `BayerCLAW.lambda.src.common.python.file_select` (full file reference)
+- `BayerCLAW.lambda.src.notifications.notifications` (full file reference)
+- `BayerCLAW.bclaw_runner.src.runner.string_subs` (full file reference)
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR includes diagram's which represent the BayerCLAW codebase. You can see how they are rendered in GitHub here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/BayerCLAW/on_boarding.md

The idea of these documents is to give a quick overview of the codebase. I am sure that lots of scientists write code in Bayer and probably they are not so interesting in the code itself, but rather the logic it contains. This said where do you stand on up-to-date diagram first documentation for your projects, as we are working on a github action which will allow generate such documentation on demand (commits/release/etc)

Any feedback is more than welcome!

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.